### PR TITLE
fix: 添加内容大小限制和裁剪功能以修复CursorWindow和TransactionTooLargeException报错

### DIFF
--- a/app/src/main/java/com/jacksen168/syncclipboard/data/model/ClipboardItem.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/data/model/ClipboardItem.kt
@@ -3,6 +3,7 @@ package com.jacksen168.syncclipboard.data.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
+import com.jacksen168.syncclipboard.util.ContentLimiter
 import java.security.MessageDigest
 import java.util.Date
 
@@ -51,7 +52,14 @@ data class ClipboardItem(
     val lastModified: Long = timestamp,
     
     // 新增字段：是否正在同步中
-    val isSyncing: Boolean = false
+    val isSyncing: Boolean = false,
+    
+    // 新增字段：用于UI显示的裁剪内容（避免UI渲染性能问题）
+    val uiContent: String = if (type == ClipboardType.TEXT && ContentLimiter.isContentTooLargeForUI(content)) {
+        ContentLimiter.truncateForUI(content)
+    } else {
+        content
+    }
 ) {
     companion object {
         /**

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/HomeScreen.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/HomeScreen.kt
@@ -366,7 +366,7 @@ fun ClipboardItemCard(
             when (item.type) {
                 ClipboardType.TEXT -> {
                     Text(
-                        text = item.content,
+                        text = item.uiContent,
                         style = MaterialTheme.typography.bodyMedium,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
@@ -375,7 +375,7 @@ fun ClipboardItemCard(
                 }
                 ClipboardType.IMAGE -> {
                     ImagePreview(
-                        imagePath = item.localPath ?: item.content,
+                        imagePath = item.localPath ?: "",
                         fileName = item.fileName,
                         modifier = Modifier.fillMaxWidth()
                     )

--- a/app/src/main/java/com/jacksen168/syncclipboard/service/ClipboardSyncService.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/service/ClipboardSyncService.kt
@@ -20,6 +20,7 @@ import com.jacksen168.syncclipboard.data.model.AppSettings
 import com.jacksen168.syncclipboard.data.repository.ClipboardRepository
 import com.jacksen168.syncclipboard.data.repository.SettingsRepository
 import com.jacksen168.syncclipboard.presentation.MainActivity
+import com.jacksen168.syncclipboard.util.ContentLimiter
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.delay
@@ -294,7 +295,7 @@ class ClipboardSyncService : Service() {
                     if (shouldUpdate) {
                         // 只有当内容不同时才更新剪贴板
                         updateClipboardFromServer(item)
-                        showSyncNotification("已从服务器同步: ${item.content.take(20)}...")
+                        showSyncNotification("已从服务器同步: ${item.uiContent.take(20)}...")
                     } else {
                         Log.d(TAG, "服务器内容与当前剪贴板相同，跳过更新")
                     }
@@ -435,7 +436,7 @@ class ClipboardSyncService : Service() {
             when (item.type) {
                 ClipboardType.TEXT -> {
                     clipboardManager.setClipboardText(item.content)
-                    Log.d(TAG, "已将文本内容写入剪贴板: ${item.content.take(20)}...")
+                    Log.d(TAG, "已将文本内容写入剪贴板: ${item.uiContent.take(20)}...")
                 }
                 ClipboardType.IMAGE -> {
                     // 图片类型：如果有本地路径，则设置图片到剪贴板
@@ -811,7 +812,7 @@ class ClipboardSyncService : Service() {
                     Log.d(TAG, "解锁后处理缓存的剪贴板内容")
                     writeToClipboard(item)
                     pendingClipboardItem = null // 清空缓存
-                    showSyncNotification("解锁后已自动写入: ${item.content.take(20)}...")
+                    showSyncNotification("解锁后已自动写入: ${item.uiContent.take(20)}...")
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "处理解锁后逻辑时出错", e)

--- a/app/src/main/java/com/jacksen168/syncclipboard/util/ContentLimiter.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/util/ContentLimiter.kt
@@ -1,0 +1,98 @@
+package com.jacksen168.syncclipboard.util
+
+/**
+ * 内容限制工具类
+ * 用于限制剪贴板内容和数据库内容的大小，避免TransactionTooLargeException和数据库行过大问题
+ */
+object ContentLimiter {
+    // 1MB限制（约100万字符）
+    private const val MAX_CONTENT_LENGTH = 1024 * 1024
+    
+    // 剪贴板内容限制（略小于1MB，留出一些空间给系统包装）
+    private const val MAX_CLIPBOARD_CONTENT_LENGTH = 900 * 1024
+    
+    // UI显示内容限制（避免UI渲染性能问题）
+    private const val MAX_UI_CONTENT_LENGTH = 10 * 1024 // 10KB
+    
+    /**
+     * 检查内容是否超过数据库限制
+     */
+    fun isContentTooLargeForDatabase(content: String): Boolean {
+        return content.toByteArray(Charsets.UTF_8).size > MAX_CONTENT_LENGTH
+    }
+    
+    /**
+     * 检查内容是否超过剪贴板限制
+     */
+    fun isContentTooLargeForClipboard(content: String): Boolean {
+        return content.toByteArray(Charsets.UTF_8).size > MAX_CLIPBOARD_CONTENT_LENGTH
+    }
+    
+    /**
+     * 检查内容是否超过UI显示限制
+     */
+    fun isContentTooLargeForUI(content: String): Boolean {
+        return content.toByteArray(Charsets.UTF_8).size > MAX_UI_CONTENT_LENGTH
+    }
+    
+    /**
+     * 裁剪内容以适应数据库存储
+     */
+    fun truncateForDatabase(content: String): String {
+        return truncateContent(content, MAX_CONTENT_LENGTH)
+    }
+    
+    /**
+     * 裁剪内容以适应剪贴板操作
+     */
+    fun truncateForClipboard(content: String): String {
+        return truncateContent(content, MAX_CLIPBOARD_CONTENT_LENGTH)
+    }
+    
+    /**
+     * 裁剪内容以适应UI显示
+     */
+    fun truncateForUI(content: String): String {
+        return truncateContent(content, MAX_UI_CONTENT_LENGTH, " [内容已被截断以提高性能]")
+    }
+    
+    /**
+     * 通用内容裁剪方法
+     */
+    private fun truncateContent(content: String, maxLength: Int, suffix: String = " [内容已被自动裁剪]"): String {
+        // 先检查字节数
+        val contentBytes = content.toByteArray(Charsets.UTF_8)
+        if (contentBytes.size <= maxLength) {
+            return content
+        }
+        
+        // 如果字节数超限，需要裁剪
+        // 使用二分查找找到合适的字符位置
+        var left = 0
+        var right = content.length
+        var result = content
+        
+        while (left <= right) {
+            val mid = (left + right) / 2
+            val truncated = content.substring(0, mid)
+            val bytes = truncated.toByteArray(Charsets.UTF_8)
+            
+            if (bytes.size <= maxLength) {
+                result = truncated
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+        
+        // 添加提示信息表示内容已被裁剪
+        return result + suffix
+    }
+    
+    /**
+     * 获取内容的字节大小
+     */
+    fun getContentByteSize(content: String): Int {
+        return content.toByteArray(Charsets.UTF_8).size
+    }
+}


### PR DESCRIPTION
feat(clipboard): 添加内容大小限制和裁剪功能(防止CursorWindow和TransactionTooLargeException报错)

- 新增 ContentLimiter 工具类，用于限制剪贴板内容大小
- 在 ClipboardItem 中添加 uiContent 字段，优化UI显示性能
- 在 ClipboardRepository 中实现内容自动裁剪逻辑
- 在 HomeScreen 中使用 uiContent 显示裁剪后的内容
- 在 MainViewModel 中添加复制时的内容裁剪处理
- 在 ClipboardManager 中增加获取和设置剪贴板时的内容检查
- 在 ClipboardSyncService 中使用裁剪后的内容进行同步操作
- 为不同场景（数据库、剪贴板、UI）设置不同的内容大小限制