### PR TITLE
feat(settings): 添加数据库重置功能和本地化支持

### DIFF
--- a/app/src/main/java/com/jacksen168/syncclipboard/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/data/repository/SettingsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
+import com.jacksen168.syncclipboard.R
 import com.jacksen168.syncclipboard.data.model.AppSettings
 import com.jacksen168.syncclipboard.data.model.ServerConfig
 import kotlinx.coroutines.flow.Flow
@@ -177,6 +178,19 @@ class SettingsRepository(private val context: Context) {
             String(decrypted)
         } catch (e: Exception) {
             encryptedPassword // 如果解密失败，返回原文
+        }
+    }
+
+    /**
+     * 重置数据库
+     */
+    suspend fun resetDatabase(context: Context) {
+        try {
+            // 删除数据库文件
+            context.deleteDatabase("clipboard_database")
+            Log.d("SettingsRepository", context.getString(R.string.database_reset_log))
+        } catch (e: Exception) {
+            Log.e("SettingsRepository", context.getString(R.string.database_reset_error_log), e)
         }
     }
 }

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/navigation/Navigation.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/navigation/Navigation.kt
@@ -20,9 +20,9 @@ import com.jacksen168.syncclipboard.presentation.screen.SettingsScreen
 /**
  * 导航路由
  */
-sealed class Screen(val route: String, val title: String, val icon: androidx.compose.ui.graphics.vector.ImageVector) {
-    object Home : Screen("home", "首页", Icons.Filled.Home)
-    object Settings : Screen("settings", "设置", Icons.Filled.Settings)
+sealed class Screen(val route: String, val titleResId: Int, val icon: androidx.compose.ui.graphics.vector.ImageVector) {
+    object Home : Screen("home", R.string.home, Icons.Filled.Home)
+    object Settings : Screen("settings", R.string.navigation_settings, Icons.Filled.Settings)
 }
 
 /**
@@ -51,10 +51,10 @@ fun SyncClipboardNavigation(
                         icon = { 
                             Icon(
                                 imageVector = screen.icon,
-                                contentDescription = screen.title
+                                contentDescription = stringResource(screen.titleResId)
                             )
                         },
-                        label = { Text(screen.title) },
+                        label = { Text(stringResource(screen.titleResId)) },
                         selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
                         onClick = {
                             navController.navigate(screen.route) {

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/HomeScreen.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/HomeScreen.kt
@@ -87,7 +87,7 @@ fun HomeScreen(
                 actions = {
                     // 状态文字提示
                     Text(
-                        text = if (uiState.isConnected) "运行中" else "未运行",
+                        text = if (uiState.isConnected) stringResource(R.string.status_running) else stringResource(R.string.status_not_running),
                         style = MaterialTheme.typography.bodyMedium,
                         color = if (uiState.isConnected) 
                             MaterialTheme.colorScheme.primary 
@@ -103,7 +103,7 @@ fun HomeScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Upload,
-                            contentDescription = "手动同步到服务器",
+                            contentDescription = stringResource(R.string.manual_sync_to_server),
                             tint = if (uiState.isConnected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
@@ -114,7 +114,7 @@ fun HomeScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
-                            contentDescription = "刷新列表"
+                            contentDescription = stringResource(R.string.refresh_list)
                         )
                     }
                 }
@@ -133,7 +133,7 @@ fun HomeScreen(
             ) {
                 Icon(
                     imageVector = if (uiState.isConnected) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = if (uiState.isConnected) "停止同步" else "开始同步"
+                    contentDescription = if (uiState.isConnected) stringResource(R.string.stop_sync) else stringResource(R.string.start_sync)
                 )
             }
         }

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/SettingsScreen.kt
@@ -118,6 +118,11 @@ fun SettingsScreen(
             )
         }
         
+        // 杂项
+        item {
+            MiscellaneousCard(viewModel = viewModel)
+        }
+        
         // 关于信息
         item {
             AboutCard()
@@ -459,8 +464,8 @@ fun SyncSettingsCard(
             
             // 剪贴板历史显示数量
             SettingItem(
-                title = "历史显示数量",
-                description = "设置剪贴板历史列表显示的数量",
+                title = stringResource(R.string.clipboard_history_count),
+                description = stringResource(R.string.clipboard_history_count_desc),
                 icon = Icons.Default.List,
                 trailing = {
                     TextButton(
@@ -476,8 +481,8 @@ fun SyncSettingsCard(
             
             // 文件下载位置
             SettingItem(
-                title = "文件下载位置",
-                description = if (appSettings.downloadLocation.isEmpty()) "点击选择下载位置" else getReadablePathFromUri(appSettings.downloadLocation),
+                title = stringResource(R.string.download_location),
+                description = if (appSettings.downloadLocation.isEmpty()) stringResource(R.string.download_location_empty) else getReadablePathFromUri(appSettings.downloadLocation),
                 icon = Icons.Default.Folder,
                 trailing = {
                     TextButton(
@@ -486,15 +491,15 @@ fun SyncSettingsCard(
                             onRequestDownloadLocationSelection()
                         }
                     ) {
-                        Text(if (appSettings.downloadLocation.isEmpty()) "选择" else "更改")
+                        Text(if (appSettings.downloadLocation.isEmpty()) stringResource(R.string.select) else stringResource(R.string.change))
                     }
                 }
             )
             
             // 文件自动保存开关
             SettingItem(
-                title = "文件自动保存",
-                description = "开启后自动保存接收到的文件",
+                title = stringResource(R.string.auto_save_files),
+                description = stringResource(R.string.auto_save_files_desc),
                 icon = Icons.Default.Save,
                 trailing = {
                     Switch(
@@ -510,12 +515,12 @@ fun SyncSettingsCard(
     if (showIntervalDialog) {
         AlertDialog(
             onDismissRequest = { showIntervalDialog = false },
-            title = { Text("设置同步间隔") },
+            title = { Text(stringResource(R.string.set_sync_interval)) },
             text = {
                 OutlinedTextField(
                     value = tempInterval,
                     onValueChange = { tempInterval = it },
-                    label = { Text("间隔时间（秒）") },
+                    label = { Text(stringResource(R.string.interval_time_seconds)) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true
                 )
@@ -546,12 +551,12 @@ fun SyncSettingsCard(
     if (showHistoryCountDialog) {
         AlertDialog(
             onDismissRequest = { showHistoryCountDialog = false },
-            title = { Text("设置历史显示数量") },
+            title = { Text(stringResource(R.string.set_clipboard_history_count)) },
             text = {
                 OutlinedTextField(
                     value = tempHistoryCount,
                     onValueChange = { tempHistoryCount = it },
-                    label = { Text("显示数量(1-100条)") },
+                    label = { Text(stringResource(R.string.display_count_items)) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     singleLine = true
                 )
@@ -700,7 +705,7 @@ fun AboutCard() {
                     tint = MaterialTheme.colorScheme.primary
                 )
                 Text(
-                    text = "关于",
+                    text = stringResource(R.string.about),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Medium
                 )
@@ -709,7 +714,7 @@ fun AboutCard() {
             // 应用信息
             SettingItem(
                 title = stringResource(R.string.app_name),
-                description = "版本 $versionName ($versionCode)",
+                description = stringResource(R.string.version_info, versionName, versionCode),
                 icon = Icons.Default.Build,
                 trailing = {
                     IconButton(
@@ -724,7 +729,7 @@ fun AboutCard() {
                         } else {
                             Icon(
                                 imageVector = Icons.Default.SystemUpdate,
-                                contentDescription = "检查更新",
+                                contentDescription = stringResource(R.string.check_for_updates),
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }
@@ -734,7 +739,7 @@ fun AboutCard() {
             
             // GitHub链接
             SettingItem(
-                title = "GitHub项目",
+                title = stringResource(R.string.github_project),
                 description = "https://github.com/jacksen168sub/SyncClipboard-Android",
                 icon = Icons.Default.Star,
                 trailing = {
@@ -748,7 +753,7 @@ fun AboutCard() {
                     }) {
                         Icon(
                             imageVector = Icons.Default.Launch,
-                            contentDescription = "打开链接"
+                            contentDescription = stringResource(R.string.open_link)
                         )
                     }
                 }
@@ -756,7 +761,7 @@ fun AboutCard() {
             
             // 服务端项目链接
             SettingItem(
-                title = "服务端",
+                title = stringResource(R.string.server_side),
                 description = "https://github.com/Jeric-X/SyncClipboard",
                 icon = Icons.Default.Storage,
                 trailing = {
@@ -770,7 +775,7 @@ fun AboutCard() {
                     }) {
                         Icon(
                             imageVector = Icons.Default.Launch,
-                            contentDescription = "打开链接"
+                            contentDescription = stringResource(R.string.open_link)
                         )
                     }
                 }
@@ -798,14 +803,14 @@ fun AboutCard() {
                             modifier = Modifier.size(20.dp)
                         )
                         Text(
-                            text = "重要说明",
+                            text = stringResource(R.string.important_notice),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Medium,
                             color = MaterialTheme.colorScheme.onErrorContainer
                         )
                     }
                     Text(
-                        text = "由于安卓系统限制,在安卓10及以上的系统应用无法在后台读取剪贴板,但可以使用基于Root权限的工具(Magisk/Xposed)解除应用后台读取剪贴版的权限,如Riru-ClipboardWhitelist或Clipboard Whitelist",
+                        text = stringResource(R.string.system_limitations_desc),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onErrorContainer
                     )
@@ -956,6 +961,91 @@ fun ExperimentalFeaturesCard(
                 }
             )
         }
+    }
+}
+
+/**
+ * 杂项卡片
+ */
+@Composable
+fun MiscellaneousCard(
+    viewModel: SettingsViewModel
+) {
+    val context = LocalContext.current
+    var showResetConfirm by remember { mutableStateOf(false) }
+    
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // 标题
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = stringResource(R.string.miscellaneous),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // 重置数据库
+            SettingItem(
+                title = stringResource(R.string.reset_database),
+                description = stringResource(R.string.reset_database_desc),
+                icon = Icons.Default.Restore,
+                trailing = {
+                    Button(
+                        onClick = { showResetConfirm = true },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        )
+                    ) {
+                        Text(stringResource(R.string.reset_button))
+                    }
+                }
+            )
+        }
+    }
+    
+    // 重置确认对话框
+    if (showResetConfirm) {
+        AlertDialog(
+            onDismissRequest = { showResetConfirm = false },
+            title = { Text(stringResource(R.string.confirm_reset_title)) },
+            text = { Text(stringResource(R.string.confirm_reset_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.resetDatabase()
+                        showResetConfirm = false
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(stringResource(R.string.confirm_reset_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetConfirm = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,12 @@
     <string name="status_disconnected">已断开</string>
     <string name="status_syncing">同步中…</string>
     <string name="last_sync_time">最后同步: %s</string>
+    <string name="status_running">运行中</string>
+    <string name="status_not_running">未运行</string>
+    <string name="manual_sync_to_server">手动同步到服务器</string>
+    <string name="refresh_list">刷新列表</string>
+    <string name="stop_sync">停止同步</string>
+    <string name="start_sync">开始同步</string>
     
     <!-- Clipboard Content -->
     <string name="clipboard_empty">剪贴板为空</string>
@@ -41,6 +47,20 @@
     <string name="sync_on_boot_desc">应用启动时自动开启剪贴板同步服务</string>
     <string name="rewrite_after_unlock">解锁屏幕后重新写入剪贴板</string>
     <string name="rewrite_after_unlock_desc">锁屏期间如内容已同步到APP但没有写入剪贴板时,解锁屏幕后自动将同步过来的内容重新写入剪贴板</string>
+    <string name="clipboard_history_count">历史显示数量</string>
+    <string name="clipboard_history_count_desc">设置剪贴板历史列表显示的数量</string>
+    <string name="download_location">文件下载位置</string>
+    <string name="download_location_empty">点击选择下载位置</string>
+    <string name="auto_save_files">文件自动保存</string>
+    <string name="auto_save_files_desc">开启后自动保存接收到的文件</string>
+    <string name="select">选择</string>
+    <string name="change">更改</string>
+    
+    <!-- Dialogs -->
+    <string name="set_sync_interval">设置同步间隔</string>
+    <string name="interval_time_seconds">间隔时间（秒）</string>
+    <string name="set_clipboard_history_count">设置历史显示数量</string>
+    <string name="display_count_items">显示数量(1-100条)</string>
     
     <!-- Other Settings -->
     <string name="other_settings">其他设置</string>
@@ -54,6 +74,33 @@
     <string name="foreground_service_keepalive">前台服务保活</string>
     <string name="foreground_service_keepalive_desc">使用前台服务机制增强应用保活能力</string>
     <string name="experimental_warning">无法确定功能能否正常运行</string>
+    
+    <!-- Miscellaneous -->
+    <string name="miscellaneous">杂项</string>
+    <string name="reset_database">重置APP数据库</string>
+    <string name="reset_database_desc">遇到问题可尝试重置数据库,清除APP所有剪贴板历史记录</string>
+    <string name="reset_button">重置</string>
+    <string name="confirm_reset_title">确认重置数据库</string>
+    <string name="confirm_reset_message">此操作将清除所有剪贴板历史记录,且无法恢复。是否继续?</string>
+    <string name="confirm_reset_action">确认重置</string>
+    <string name="database_reset_success">数据库已重置，应用即将重启</string>
+    <string name="database_reset_failed">重置数据库失败: %s</string>
+    <string name="database_reset_log">数据库已重置</string>
+    <string name="database_reset_error_log">重置数据库时出错</string>
+    
+    <!-- About -->
+    <string name="about">关于</string>
+    <string name="version_info">版本 %1$s (%2$s)</string>
+    <string name="check_for_updates">检查更新</string>
+    <string name="github_project">GitHub项目</string>
+    <string name="server_side">服务端</string>
+    <string name="open_link">打开链接</string>
+    <string name="important_notice">重要说明</string>
+    <string name="system_limitations_desc">由于安卓系统限制,在安卓10及以上的系统应用无法在后台读取剪贴板,但可以使用基于Root权限的工具(Magisk/Xposed)解除应用后台读取剪贴版的权限,如Riru-ClipboardWhitelist或Clipboard Whitelist</string>
+    
+    <!-- Navigation -->
+    <string name="home">首页</string>
+    <string name="navigation_settings">设置</string>
     
     <!-- Notification -->
     <string name="notification_channel_name">剪贴板同步</string>


### PR DESCRIPTION
- 在设置页面新增杂项卡片，支持重置APP数据库
- 实现数据库重置逻辑，包括文件删除和异常处理
- 添加重置确认对话框，防止误操作
- 为导航栏标题和多个界面元素添加字符串资源引用
- 更新设置页面中的文本内容，统一使用本地化字符串
- 完善关于页面的文本描述和链接内容
- 优化HomeScreen中的状态文本显示逻辑
- 在SettingsRepository中增加resetDatabase方法
- 在SettingsViewModel中实现resetDatabase和restartApp方法
- 补充多语言字符串资源定义，支持中英文显示