### PR TITLE
feat(sync): 实现应用前台激活时的剪贴板内容检查

### DIFF
--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/MainActivity.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/MainActivity.kt
@@ -383,6 +383,9 @@ class MainActivity : ComponentActivity() {
         super.onResume()
         // 在 Activity 恢复时重新应用隐藏设置
         reapplyHideInRecentsIfNeeded()
+        
+        // 当从后台返回前台时，通知服务检查剪贴板内容
+        notifyServiceAppForeground()
     }
     
     override fun onPause() {
@@ -476,5 +479,14 @@ class MainActivity : ComponentActivity() {
         } catch (e: Exception) {
             uri.toString()
         }
+    }
+    
+    /**
+     * 通知服务应用已从后台返回前台
+     */
+    private fun notifyServiceAppForeground() {
+        // 发送广播通知ClipboardSyncService应用已从后台返回前台
+        val intent = Intent("com.jacksen168.syncclipboard.APP_FOREGROUND")
+        sendBroadcast(intent)
     }
 }


### PR DESCRIPTION
- 在 MainActivity 中添加应用前台激活时的通知逻辑
- 在 ClipboardSyncService 中注册应用生命周期监听器
- 实现 handleAppForeground 方法以检查并同步剪贴板内容
- 添加该功能重复内容检测避免不必要的同步操作
- 增加该功能重试机制提高剪贴板内容读取成功率

close #8 