### PR TITLE
feat(update): 优化APK更新检测逻辑

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.jacksen168.syncclipboard"
         minSdk = 28
         targetSdk = 35
-        versionCode = 7
-        versionName = "1.3.2-alpha"
+        versionCode = 8
+        versionName = "1.3.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
- 将版本号从 1.3.2-alpha 更新至 1.3.3
- 仅在找到以 "-signed.apk" 结尾的签名APK时才触发更新提示
- 增加日志记录，便于调试资产查找和版本比较过程
- 若未找到签名APK，则不提示用户进行更新
- 提高更新检查的准确性与安全性