### PR TITLE
feat(ui): 更新导航栏和设置卡片样式

### DIFF
--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/navigation/Navigation.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/navigation/Navigation.kt
@@ -15,9 +15,10 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.jacksen168.syncclipboard.R
 import com.jacksen168.syncclipboard.presentation.screen.HomeScreen
-import com.jacksen168.syncclipboard.presentation.screen.LogScreen // 添加日志页面导入
+import com.jacksen168.syncclipboard.presentation.screen.LogScreen
 import com.jacksen168.syncclipboard.presentation.screen.SettingsScreen
 import com.jacksen168.syncclipboard.data.repository.SettingsRepository
+import com.jacksen168.syncclipboard.presentation.theme.SelectedNavItemColor
 import android.content.Context
 import androidx.lifecycle.viewmodel.compose.viewModel
 
@@ -26,7 +27,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
  */
 sealed class Screen(val route: String, val titleResId: Int, val icon: androidx.compose.ui.graphics.vector.ImageVector) {
     object Home : Screen("home", R.string.home, Icons.Filled.Home)
-    object Logs : Screen("logs", R.string.logs, Icons.Filled.List) // 添加日志页面路由
+    object Logs : Screen("logs", R.string.logs, Icons.Filled.List)
     object Settings : Screen("settings", R.string.navigation_settings, Icons.Filled.Settings)
 }
 
@@ -44,13 +45,15 @@ fun SyncClipboardNavigation(
     
     val items = listOf(
         Screen.Home,
-        Screen.Logs, // 添加日志页面到导航项
+        Screen.Logs,
         Screen.Settings
     )
     
     Scaffold(
         bottomBar = {
-            NavigationBar {
+            NavigationBar(
+                containerColor = MaterialTheme.colorScheme.surface
+            ) {
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentDestination = navBackStackEntry?.destination
                 
@@ -78,7 +81,10 @@ fun SyncClipboardNavigation(
                                 // Restore state when reselecting a previously selected item
                                 restoreState = true
                             }
-                        }
+                        },
+                        colors = NavigationBarItemDefaults.colors(
+                            indicatorColor = SelectedNavItemColor,
+                        )
                     )
                 }
             }
@@ -92,7 +98,7 @@ fun SyncClipboardNavigation(
             composable(Screen.Home.route) {
                 HomeScreen()
             }
-            composable(Screen.Logs.route) { // 添加日志页面路由
+            composable(Screen.Logs.route) {
                 val settingsRepository = SettingsRepository(context)
                 LogScreen(
                     onCreateLogFile = onCreateLogFile,

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/screen/SettingsScreen.kt
@@ -149,7 +149,7 @@ fun ServerSettingsCard(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -382,7 +382,7 @@ fun SyncSettingsCard(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -687,7 +687,7 @@ fun AboutCard() {
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -833,7 +833,7 @@ fun OtherSettingsCard(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -898,7 +898,7 @@ fun ExperimentalFeaturesCard(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(
@@ -978,7 +978,7 @@ fun MiscellaneousCard(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         Column(

--- a/app/src/main/java/com/jacksen168/syncclipboard/presentation/theme/Color.kt
+++ b/app/src/main/java/com/jacksen168/syncclipboard/presentation/theme/Color.kt
@@ -38,6 +38,9 @@ val Neutral900 = Color(0xFF121316)
 val Error500 = Color(0xFFBA1A1A)
 val Error300 = Color(0xFFFFB4AB)
 
+// 自定义颜色
+val SelectedNavItemColor = Color(0xC6A5D6A7) // 导航栏选中项背景色
+
 // 兼容的颜色方案，避免使用新的Material 3属性
 private val LightColorScheme = lightColorScheme(
     primary = Primary500,


### PR DESCRIPTION
- 添加日志页面到导航项并完善路由配置
- 设置底部导航栏容器颜色为 surface
- 为导航栏选中项添加自定义指示器颜色
- 统一设置卡片背景颜色为 surface
- 引入 SelectedNavItemColor 主题颜色值